### PR TITLE
Fix scaling for throughput

### DIFF
--- a/scripts/benchmark_pipelines.py
+++ b/scripts/benchmark_pipelines.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
         )
     else:
         num_tokens = (args.batch_size * args.output_length)
-        tokens_per_sec = num_tokens / (latencies / 1e6)
+        tokens_per_sec = num_tokens / (latencies / 1e3)
         print(
             "Throughput: "
             f"{tokens_per_sec.mean().astype(np.uint64)} tokens/s "


### PR DESCRIPTION
torch.cuda.Event.elapsed_time returns milliseconds (1e-3), but we were scaling as if it returned microseconds (1e-6)

https://pytorch.org/docs/stable/_modules/torch/cuda/streams.html#Event.elapsed_time