### PR TITLE
Enable more SM architectures in the prebuild docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ To learn more about text generation with LLMs, check out [this guide](https://hu
 # Support Matrix
 We test Optimum-NVIDIA on 4090, L40S, and H100 Tensor Core GPUs, though it is expected to work on any GPU based on the following architectures:
 * Volta
-* Turing
-* Ampere
+* Turing (with experimental support for T4 / RTX Quadro x000)
+* Ampere (A100 is supported. Experimental support for A10, A40, RTX Ax000)
 * Hopper
 * Ada-Lovelace
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To learn more about text generation with LLMs, check out [this guide](https://hu
 We test Optimum-NVIDIA on 4090, L40S, and H100 Tensor Core GPUs, though it is expected to work on any GPU based on the following architectures:
 * Volta
 * Turing (with experimental support for T4 / RTX Quadro x000)
-* Ampere (A100 is supported. Experimental support for A10, A40, RTX Ax000)
+* Ampere (A100/A30 are supported. Experimental support for A10, A40, RTX Ax000)
 * Hopper
 * Ada-Lovelace
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,12 @@
 FROM tensorrt_llm/release:latest as BUILDER
 
-ARG TARGET_CUDA_ARCHS="80-real;86-real;89-real;90-real"
+# 70 = V100
+# 75 = T4/RTX Quadro
+# 80 = A100/A30
+# 86 = A10/A40/RTX Axxx
+# 89 = L4/L40/L40s/RTX Ada/4090
+# 90 = H100/H200
+ARG TARGET_CUDA_ARCHS="70-real;75-real;80-real;86-real;89-real;90-real"
 
 COPY . /opt/optimum-nvidia
 


### PR DESCRIPTION
This PR enables the following CUDA architecture for the prebuild container:

- 70 = V100
- 75 = T4/RTX Quadro
- 80 = A100/A30
- 86 = A10/A40/RTX Axxx
- 89 = L4/L40/L40s/RTX Ada/4090
- 90 = H100/H200