### PR TITLE
Fixed Repetition Penalty default value

### DIFF
--- a/src/optimum/nvidia/runtime.py
+++ b/src/optimum/nvidia/runtime.py
@@ -221,7 +221,7 @@ class TensorRTForCausalLM(TensorRTPreTrainedModel):
         temperature: float = 1.0,
         top_k: int = 50,
         top_p: float = 1.0,
-        repetition_penalty: float = 0.0,
+        repetition_penalty: float = 1.0,
         length_penalty: float = 1.0,
         seed: int = 0,
         pad_token_id: int = 0,


### PR DESCRIPTION
Current default value for repetition penalty is set to 0, this is value is not neutral to the generation output as it is pushing the model to repeat tokens, default value should be 1.0 as in [huggingface documentation](https://huggingface.co/docs/transformers/internal/generation_utils#transformers.EncoderRepetitionPenaltyLogitsProcessor.penalty).

